### PR TITLE
bugfix

### DIFF
--- a/custom_components/buienradar_precipitation_forecast/__init__.py
+++ b/custom_components/buienradar_precipitation_forecast/__init__.py
@@ -9,7 +9,11 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .api import ForecastApiClient
 from .const import DOMAIN, PLATFORM, STARTUP_MESSAGE
 
+from homeassistant.const import Platform
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
 _LOGGER: logging.Logger = logging.getLogger(__package__)
+
 
 
 # async def async_setup(hass: HomeAssistant, config: Config):
@@ -30,6 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id] = client
 
-    hass.async_add_job(hass.config_entries.async_forward_entry_setup(entry, PLATFORM))
+#    hass.async_add_job(hass.config_entries.async_forward_entry_setup(entry, PLATFORM))
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True


### PR DESCRIPTION
This custom component has stopped working in HA version 2025.6.0 because the use of hass.config_entries.async_forward_entry_setup was deprecated in this release.